### PR TITLE
Fix shutdown method and make it public. Implement configurable timeouts

### DIFF
--- a/electrum/network.go
+++ b/electrum/network.go
@@ -354,8 +354,19 @@ func (s *Server) request(method string, params []interface{}, v interface{}) err
 
 func (s *Server) Shutdown() {
 	close(s.quit)
-	_ = s.transport.Close()
+	if s.transport != nil {
+		_ = s.transport.Close()
+	}
 	s.transport = nil
 	s.handlers = nil
 	s.pushHandlers = nil
+}
+
+func (s *Server) IsShutdown() bool {
+	select {
+	case <-s.quit:
+		return true
+	default:
+	}
+	return false
 }

--- a/electrum/network.go
+++ b/electrum/network.go
@@ -354,7 +354,9 @@ func (s *Server) request(method string, params []interface{}, v interface{}) err
 }
 
 func (s *Server) Shutdown() {
-	close(s.quit)
+	if !s.IsShutdown() {
+		close(s.quit)
+	}
 	if s.transport != nil {
 		_ = s.transport.Close()
 	}

--- a/electrum/network.go
+++ b/electrum/network.go
@@ -50,6 +50,7 @@ type Transport interface {
 	SendMessage([]byte) error
 	Responses() <-chan []byte
 	Errors() <-chan error
+	Close() error
 }
 
 // TCPTransport store informations about the TCP transport.
@@ -134,6 +135,10 @@ func (t *TCPTransport) Responses() <-chan []byte {
 // Errors returns chan to TCP transport errors.
 func (t *TCPTransport) Errors() <-chan error {
 	return t.errors
+}
+
+func (t *TCPTransport) Close() error {
+	return t.conn.Close()
 }
 
 type container struct {
@@ -338,7 +343,7 @@ func (s *Server) request(method string, params []interface{}, v interface{}) err
 
 func (s *Server) Shutdown() {
 	close(s.quit)
-
+	_ = s.transport.Close()
 	s.transport = nil
 	s.handlers = nil
 	s.pushHandlers = nil

--- a/electrum/network.go
+++ b/electrum/network.go
@@ -152,7 +152,7 @@ type ServerOptions struct {
 // Server stores information about the remote server.
 type Server struct {
 	transport Transport
-	opts      ServerOptions
+	opts      *ServerOptions
 
 	handlers     map[uint64]chan *container
 	handlersLock sync.RWMutex
@@ -167,7 +167,7 @@ type Server struct {
 }
 
 // NewServer initialize a new remote server.
-func NewServer(opts ServerOptions) *Server {
+func NewServer(opts *ServerOptions) *Server {
 	s := &Server{
 		handlers:     make(map[uint64]chan *container),
 		pushHandlers: make(map[string][]chan *container),

--- a/electrum/network.go
+++ b/electrum/network.go
@@ -224,7 +224,7 @@ func (s *Server) listen() {
 		select {
 		case err := <-s.transport.Errors():
 			s.Error <- err
-			s.shutdown()
+			s.Shutdown()
 		case bytes := <-s.transport.Responses():
 			result := &container{
 				content: bytes,
@@ -336,7 +336,7 @@ func (s *Server) request(method string, params []interface{}, v interface{}) err
 	return nil
 }
 
-func (s *Server) shutdown() {
+func (s *Server) Shutdown() {
 	close(s.quit)
 
 	s.transport = nil

--- a/electrum/network.go
+++ b/electrum/network.go
@@ -182,7 +182,7 @@ func NewServer(opts *ServerOptions) *Server {
 }
 
 // ConnectTCP connects to the remote server using TCP.
-func (s *Server) ConnectTCP(addr string, ) error {
+func (s *Server) ConnectTCP(addr string) error {
 	if s.transport != nil {
 		return ErrServerConnected
 	}

--- a/electrum/network.go
+++ b/electrum/network.go
@@ -318,6 +318,7 @@ func (s *Server) request(method string, params []interface{}, v interface{}) err
 
 	err = s.transport.SendMessage(bytes)
 	if err != nil {
+		s.Shutdown()
 		return err
 	}
 


### PR DESCRIPTION
Electrumx does automatically close idle connections as per [https://electrumx.readthedocs.io/en/latest/environment.html#envvar-SESSION_TIMEOUT](https://electrumx.readthedocs.io/en/latest/environment.html#envvar-SESSION_TIMEOUT)

However if you're opening a lot of connections at the same time, say in a multi-threaded application such as a HTTP server/handler, then it very easy to hit the SESSION_LIMIT. Control over closing the underlying connection is important in this scenario.

This PR makes the `shutdown()` method publicly callable. It also fixes the shutdown process to properly close the underlying TCP transport connection. Finally, it implements configurable connection and request timeouts