### PR TITLE
Handle error string returned in the JSON-RPC response

### DIFF
--- a/electrum/network.go
+++ b/electrum/network.go
@@ -143,10 +143,6 @@ func (e *apiErr) UnmarshalJSON(data []byte) error {
 		if _, ok := v["message"]; ok {
 			e.Message = fmt.Sprint(v["message"])
 		}
-
-		// if _, ok := v["data"]; ok {
-		// 	e.Data = fmt.Sprint(v["data"])
-		// }
 	default:
 		return fmt.Errorf("unsupported type: %v", v)
 	}

--- a/electrum/network.go
+++ b/electrum/network.go
@@ -185,7 +185,7 @@ func (s *Client) listen() {
 			err := json.Unmarshal(bytes, msg)
 			if err != nil {
 				if DebugMode {
-					log.Printf("Unmarshal received message failed: %v", err)
+					log.Printf("unmarshal received message [%s] failed: [%v]", bytes, err)
 				}
 				result.err = fmt.Errorf("Unmarshal received message failed: %v", err)
 			} else if msg.Error != nil {

--- a/electrum/network.go
+++ b/electrum/network.go
@@ -112,6 +112,28 @@ func NewClientSSL(ctx context.Context, addr string, config *tls.Config) (*Client
 	return c, nil
 }
 
+// NewClientWebSocket initialize a new client for remote server and connects to
+// the remote server using WebSocket.
+func NewClientWebSocket(ctx context.Context, url string, config *tls.Config) (*Client, error) {
+	transport, err := NewWebSocketTransport(ctx, url, config)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &Client{
+		handlers:     make(map[uint64]chan *container),
+		pushHandlers: make(map[string][]chan *container),
+
+		Error: make(chan error),
+		quit:  make(chan struct{}),
+	}
+
+	c.transport = transport
+	go c.listen()
+
+	return c, nil
+}
+
 // JSON-RPC 2.0 Error Object
 // See: https://www.jsonrpc.org/specificationJSON#error_object
 type apiErr struct {

--- a/electrum/transport_ws.go
+++ b/electrum/transport_ws.go
@@ -1,0 +1,104 @@
+package electrum
+
+import (
+	"context"
+	"crypto/tls"
+	"log"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+type WebSocketTransport struct {
+	conn      *websocket.Conn
+	responses chan []byte
+	errors    chan error
+}
+
+// NewWebSocketTransport initializes new WebSocket transport.
+func NewWebSocketTransport(
+	ctx context.Context,
+	url string,
+	tlsConfig *tls.Config,
+) (*WebSocketTransport, error) {
+	dialer := websocket.Dialer{
+		TLSClientConfig: tlsConfig,
+	}
+
+	conn, response, err := dialer.DialContext(ctx, url, nil)
+	if err != nil {
+		if DebugMode {
+			log.Printf(
+				"%s [debug] connect -> status: %v, error: %v",
+				time.Now().Format("2006-01-02 15:04:05"),
+				response.Status,
+				err,
+			)
+		}
+		return nil, err
+	}
+
+	ws := &WebSocketTransport{
+		conn:      conn,
+		responses: make(chan []byte),
+		errors:    make(chan error),
+	}
+
+	go ws.listen()
+
+	return ws, nil
+}
+
+func (t *WebSocketTransport) listen() {
+	defer t.conn.Close()
+
+	for {
+		_, msg, err := t.conn.ReadMessage()
+		if DebugMode {
+			log.Printf(
+				"%s [debug] %s -> msg: %s, err: %v",
+				time.Now().Format("2006-01-02 15:04:05"),
+				t.conn.RemoteAddr(),
+				msg,
+				err,
+			)
+		}
+		if err != nil {
+			t.errors <- err
+			break
+		}
+
+		t.responses <- msg
+	}
+}
+
+// SendMessage sends a message to the remote server through the WebSocket transport.
+func (t *WebSocketTransport) SendMessage(body []byte) error {
+	if DebugMode {
+		log.Printf("%s [debug] %s <- %s", time.Now().Format("2006-01-02 15:04:05"), t.conn.RemoteAddr(), body)
+	}
+
+	return t.conn.WriteMessage(websocket.TextMessage, body)
+}
+
+// Responses returns chan to WebSocket transport responses.
+func (t *WebSocketTransport) Responses() <-chan []byte {
+	return t.responses
+}
+
+// Errors returns chan to WebSocket transport errors.
+func (t *WebSocketTransport) Errors() <-chan error {
+	return t.errors
+}
+
+// Close closes WebSocket transport.
+func (t *WebSocketTransport) Close() error {
+	// Cleanly close the connection by sending a close message and then
+	// waiting (with timeout) for the server to close the connection.
+	err := t.conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+	if err != nil {
+		log.Printf("%s [error] %s -> close error: %s", time.Now().Format("2006-01-02 15:04:05"), t.conn.RemoteAddr(), err)
+	}
+
+	return t.conn.Close()
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/btcsuite/btcd v0.23.1
 	github.com/btcsuite/btcd/btcutil v1.1.1
+	github.com/gorilla/websocket v1.5.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=


### PR DESCRIPTION
Closes: https://github.com/checksum0/go-electrum/issues/5

Here we provide a workaround for servers that don't follow the JSON-RPC 2.0 specification for error objects.

According to the specification, an error should be an object containing `code`, `message`, and `data` properties (see: https://www.jsonrpc.org/specification#error_object).
Unfortunately, Electrs returns an error as a string (see: https://github.com/Blockstream/esplora/issues/453).

We define an error unmarshaling function to handle both types of errors.

Sample outputs from servers that the client has to handle:
**ElectrumX**
```sh
✗ echo '{"jsonrpc": "2.0", "method": "blockchain.block.header", "params": [4294967295], "id": 0}' | netcat 49.12.127.114 10068
{"jsonrpc":"2.0","error":{"code":1,"message":"height 4,294,967,295 out of range"},"id":0}
```

**Fulcrum**
```sh
✗ echo '{"jsonrpc": "2.0", "method": "blockchain.block.header", "params": [4294967295], "id": 0}' | netcat 203.132.94.196 51001
{"error":{"code":1,"message":"Invalid height"},"id":0,"jsonrpc":"2.0"}
```


**Esplora/Electrs**
```sh
✗ echo '{"jsonrpc": "2.0", "method": "blockchain.block.header", "params": [4294967295], "id": 0}' | netcat 35.225.54.191 50001
{"error":"missing header","id":0,"jsonrpc":"2.0"}
```