### PR TITLE
Handle error string returned in the JSON-RPC response

### DIFF
--- a/electrum/network.go
+++ b/electrum/network.go
@@ -143,10 +143,6 @@ func (e *apiErr) UnmarshalJSON(data []byte) error {
 		if _, ok := v["message"]; ok {
 			e.Message = fmt.Sprint(v["message"])
 		}
-
-		// if _, ok := v["data"]; ok {
-		// 	e.Data = fmt.Sprint(v["data"])
-		// }
 	default:
 		return fmt.Errorf("unsupported type: %v", v)
 	}

--- a/electrum/network.go
+++ b/electrum/network.go
@@ -185,7 +185,7 @@ func (s *Client) listen() {
 			err := json.Unmarshal(bytes, msg)
 			if err != nil {
 				if DebugMode {
-					log.Printf("Unmarshal received message failed: %v", err)
+					log.Printf("unmarshal received message [%s] failed: [%v]", bytes, err)
 				}
 				result.err = fmt.Errorf("Unmarshal received message failed: %v", err)
 			} else if msg.Error != nil {


### PR DESCRIPTION
Closes: https://github.com/checksum0/go-electrum/issues/5

Here we provide a workaround for servers that don't follow the JSON-RPC 2.0 specification for error objects.

According to the specification, an error should be an object containing `code`, `message`, and `data` properties (see: https://www.jsonrpc.org/specification#error_object).
Unfortunately, Electrs returns an error as a string (see: https://github.com/Blockstream/esplora/issues/453).

We define an error unmarshaling function to handle both types of errors.

Sample outputs from servers that the client has to handle:
**ElectrumX**
```sh
✗ echo '{"jsonrpc": "2.0", "method": "blockchain.block.header", "params": [4294967295], "id": 0}' | netcat 49.12.127.114 10068
{"jsonrpc":"2.0","error":{"code":1,"message":"height 4,294,967,295 out of range"},"id":0}
```

**Fulcrum**
```sh
✗ echo '{"jsonrpc": "2.0", "method": "blockchain.block.header", "params": [4294967295], "id": 0}' | netcat 203.132.94.196 51001
{"error":{"code":1,"message":"Invalid height"},"id":0,"jsonrpc":"2.0"}
```


**Esplora/Electrs**
```sh
✗ echo '{"jsonrpc": "2.0", "method": "blockchain.block.header", "params": [4294967295], "id": 0}' | netcat 35.225.54.191 50001
{"error":"missing header","id":0,"jsonrpc":"2.0"}
```